### PR TITLE
feat: 指導ツール削除

### DIFF
--- a/app/controllers/library/teaching_materials_controller.rb
+++ b/app/controllers/library/teaching_materials_controller.rb
@@ -51,6 +51,17 @@ class Library::TeachingMaterialsController < Library::BaseLibraryController
     end
   end
 
+  def destroy
+    @teaching_material =
+      current_user.teaching_materials.find(params[:id])
+
+    @teaching_material.destroy
+
+    redirect_to library_disease_teaching_materials_path,
+                status: :see_other,
+                notice: t("defaults.flash_message.deleted", item: TeachingMaterial.model_name.human)
+  end
+
   private
 
   def teaching_material_params

--- a/app/javascript/controllers/card_link_controller.js
+++ b/app/javascript/controllers/card_link_controller.js
@@ -7,11 +7,8 @@ export default class extends Controller {
   }
 
   go(event) {
-    // 親要素（.card）へのクリックイベント伝播を止める
-    if (event.target.closest("[data-stop-card-link]")) {
-      event.stopPropagation()
-      return
-    }
+    // 削除・編集ボタンがクリックされた場合はカード遷移しない
+    if (event.target.closest("a")) return
 
     window.location.href = this.urlValue
   }

--- a/app/views/library/teaching_materials/index.html.erb
+++ b/app/views/library/teaching_materials/index.html.erb
@@ -48,17 +48,15 @@
               <!-- 編集 -->
               <%= link_to edit_library_disease_teaching_material_path(@disease, tm),
                     class: "icon-btn",
-                    title: "編集",
-                    data: { stop_card_link: true } do %>
+                    title: "編集" do %>
                 <%= render "shared/icons/pencil" %>
               <% end %>
 
               <!-- 削除 -->
-              <%= link_to "library_disease_teaching_material_path(@disease, tm)",
+              <%= link_to library_disease_teaching_material_path(@disease, tm),
                     data: {
                       turbo_method: :delete,
-                      turbo_confirm: "削除しますか？",
-                      stop_card_link: true
+                      turbo_confirm: "削除しますか？"
                     },
                     class: "icon-btn text-error",
                     title: "削除" do %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,7 @@ Rails.application.routes.draw do
   root "pages#top"
   namespace :library do
     resources :diseases, only: %i[index] do
-      resources :teaching_materials, only: %i[index new create edit update]
+      resources :teaching_materials
     end
   end
 


### PR DESCRIPTION
## 概要
登録済み指導ツールの削除機能を実装しました

## 作業内容
- 一覧画面に削除アイコンの設置
- 削除アクション追加
- 削除時の確認ダイアログの実装
- フラッシュメッセージの表示
-削除後のリダイレクト設定

Closes: #23 
