### PR TITLE
fix: build commandからapt-get実行を削除

### DIFF
--- a/bin/render-build.sh
+++ b/bin/render-build.sh
@@ -1,8 +1,5 @@
 set -o errexit
 
-apt-get update
-apt-get install -y poppler-utils libvips
-
 bundle install
 bundle exec rails assets:precompile
 bundle exec rails assets:clean


### PR DESCRIPTION
## 概要
build commandから画像処理パッケージの apt-get 実行を削除しました。

Closes: #69 