### PR TITLE
fix: 指導ツールに関連疾患が1件しか表示されない問題を修正

### DIFF
--- a/app/controllers/library/teaching_materials_controller.rb
+++ b/app/controllers/library/teaching_materials_controller.rb
@@ -1,13 +1,22 @@
 class Library::TeachingMaterialsController < Library::BaseLibraryController
   def index
-    @q =
+    # 検索条件用のベースクエリ
+    # 疾患で絞り込むために JOIN を使う（ここでは表示用の関連は考えない）
+    base =
       current_user.teaching_materials
                   .joins(:diseases)
                   .where(diseases: { id: @disease.id })
-                  .ransack(params[:q])
 
+    # Ransack による検索条件の適用
+    # JOIN済みの Relation に対して検索条件を追加する
+    @q = base.ransack(params[:q])
+
+    # 表示用のクエリ
+    # 疾患での絞り込みは検索用に限定し、
+    # 表示用には教材を改めて取得して関連を正しく読み込む
     @teaching_materials =
-      @q.result(distinct: true)
+      TeachingMaterial
+        .where(id: @q.result.select(:id))
         .includes(
           :diseases,
           document_attachment: :blob


### PR DESCRIPTION
## 概要
指導ツールに関連疾患が1件しか表示されないバグを修正しました。

## 作業内容
- 検索条件用のクエリ（JOIN）と、表示用データ取得のクエリを分離
- Ransack を用いた検索処理を維持したまま、教材が持つ 全ての疾患情報を正しく表示できるように修正

Closes: #83 