### PR TITLE
test: 指導ツール検索のリクエストスペックを追加

### DIFF
--- a/spec/requests/library/teaching_materials_spec.rb
+++ b/spec/requests/library/teaching_materials_spec.rb
@@ -47,6 +47,19 @@ RSpec.describe "Library::TeachingMaterials", type: :request do
         expect(response).to have_http_status(:not_found)
       end
     end
+
+    context "指導ツール検索" do
+      before do
+        sign_in user
+      end
+
+      it "検索パラメータを受け取れること" do
+        get library_disease_teaching_materials_path(disease),
+          params: { q: { title_or_description_cont: "糖尿病" } }
+
+        expect(response).to have_http_status(:ok)
+      end
+    end
   end
 
   describe "POST /library/diseases/:disease_id/teaching_materials" do


### PR DESCRIPTION
## 概要
指導ツール検索について、正しくリクエストできることを確認するため、リクエストスペックを追加しました。

## 作業内容
- リクエストスペックでは「検索できているか」ではなく、パラメータを渡したら成功するかを確認

Closes: #117 