### PR TITLE
fix: Turbo Streamの対象不一致によりメモ一覧が更新されない問題を修正

### DIFF
--- a/app/views/library/knowledge_memos/_knowledge_memos.html.erb
+++ b/app/views/library/knowledge_memos/_knowledge_memos.html.erb
@@ -4,17 +4,13 @@
     <!-- 左：一覧 -->
     <div class="w-1/2 space-y-2">
       <% knowledge_memos.each do |memo| %>
-        <div id="memo_<%= memo.id %>">
-          <%= render "memo_card", memo: memo %>
-        </div>
+        <%= render "memo_card", memo: memo %>
       <% end %>
     </div>
 
     <!-- 右：詳細 -->
     <div class="w-1/2 pl-4">
-      <turbo-frame id="memo_detail">
-        <%= render "detail", memo: selected_memo %>
-      </turbo-frame>
+      <%= render "detail", memo: selected_memo %>
     </div>
 
   </div>

--- a/app/views/library/knowledge_memos/_memo_card.html.erb
+++ b/app/views/library/knowledge_memos/_memo_card.html.erb
@@ -1,29 +1,30 @@
-<%= link_to library_disease_knowledge_memo_path(@disease, memo),
-    data: { turbo_frame: "memo_detail" } do %>
+<div id="memo_<%= memo.id %>">
+  <%= link_to library_disease_knowledge_memo_path(@disease, memo),
+      data: { turbo_frame: "memo_detail" } do %>
 
-  <div class="card cursor-pointer transition rounded-sm mb-2 transition rounded-sm mb-2 bg-base-100 transition-all duration-150 ease-in-out hover:shadow-sm hover:bg-base-200 hover:scale-102 active:scale-98">
+    <div class="card cursor-pointer transition rounded-sm mb-2 transition rounded-sm mb-2 bg-base-100 transition-all duration-150 ease-in-out hover:shadow-sm hover:bg-base-200 hover:scale-102 active:scale-98">
 
-    <div class="card-body p-4 relative">
+      <div class="card-body p-4 relative">
 
-      <div class="flex items-center gap-2 min-w-0">
-        <%= render "shared/icons/bars-3-bottom-left" %>
+        <div class="flex items-center gap-2 min-w-0">
+          <%= render "shared/icons/bars-3-bottom-left" %>
 
-        <h2 class="card-title text-sm flex-1 min-w-0">
-          <span class="truncate block w-full">
-            <%= memo.title %>
-          </span>
-        </h2>
+          <h2 class="card-title text-sm flex-1 min-w-0">
+            <span class="truncate block w-full">
+              <%= memo.title %>
+            </span>
+          </h2>
+        </div>
+
+        <p class="text-xs text-base-content/70 line-clamp-1 break-words">
+          <%= memo.content %>
+        </p>
+
+        <p class="text-xs text-base-content/40 text-right">
+          <%= l(memo.updated_at, format: :short) %>
+        </p>
+
       </div>
-
-      <p class="text-xs text-base-content/70 line-clamp-1 break-words">
-        <%= memo.content %>
-      </p>
-
-      <p class="text-xs text-base-content/40 text-right">
-        <%= l(memo.updated_at, format: :short) %>
-      </p>
-
     </div>
-  </div>
-
-<% end %>
+  <% end %>
+</div>


### PR DESCRIPTION
## 概要
ナレッジメモ編集時に、詳細ビューは更新されるものの一覧側の表示が更新されない不具合を修正しました。

Turbo Streamで一覧アイテムの差し替えを行っていましたが、
対象要素とパーシャルの構造が一致していなかったため、
意図通りにDOMが更新されていませんでした。

本修正により、編集後に一覧・詳細の両方が正しく同期されるようになっています。

## 作業内容
- memo_cardパーシャルにルート要素（id="memo_xxx"）を含めるよう修正
- 一覧側でのラッパーdiv（id付き）を削除し、パーシャルに責務を集約
※ Turbo Streamのreplace対象はルート要素ごと置き換わるため、
  パーシャル側とDOM構造を一致させる必要がある点に注意。
- Turbo Frame構成の整理（不要なネストの見直し）
  - detailパーシャル内の二重turbo-frameを解消

Closes: #148 