### PR TITLE
feat: アカウント編集・削除機能の追加

### DIFF
--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -1,0 +1,4 @@
+class AccountsController < ApplicationController
+  def show
+  end
+end

--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -19,6 +19,14 @@ class AccountsController < ApplicationController
     end
   end
 
+  def destroy
+    @account = current_user
+    @account.destroy!
+
+    redirect_to root_path,
+      notice: t("defaults.flash_message.deleted", item: "アカウント")
+  end
+
   private
 
   def account_params

--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -1,4 +1,27 @@
 class AccountsController < ApplicationController
+  before_action :authenticate_user!
+
   def show
+    @account = current_user
+  end
+
+  def edit
+    @account = current_user
+  end
+
+  def update
+    @account = current_user
+    if @account.update(account_params)
+      redirect_to account_path,
+      notice: t("defaults.flash_message.updated", item: "アカウント情報")
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def account_params
+    params.require(:user).permit(:name, :email)
   end
 end

--- a/app/views/accounts/edit.html.erb
+++ b/app/views/accounts/edit.html.erb
@@ -1,0 +1,61 @@
+<div class="max-w-xl mx-auto mt-10">
+  <h1 class="text-base-content text-2xl font-bold mb-6">アカウント編集</h1>
+
+  <%= form_with model: current_user,
+                url: account_path,
+                method: :patch,
+                local: true do |f| %>
+
+    <% if current_user.errors.any? %>
+      <div class="mb-6 border border-l-4 rounded-sm border-error bg-error/10 p-4 text-error">
+        <ul class="list-disc pl-5">
+          <% current_user.errors.full_messages.each do |msg| %>
+            <li><%= msg %></li>
+          <% end %>
+        </ul>
+      </div>
+    <% end %>
+
+    <div class="p-6 space-y-6">
+
+      <!-- ユーザー名 -->
+      <div>
+        <%= f.label :name,
+              "ユーザー名",
+              class: "text-sm text-base-content/70" %>
+
+        <%= f.text_field :name,
+              class: "w-full mt-1 text-lg font-medium text-base-content
+                      border border-base-300 rounded-sm p-2
+                      focus:outline-none focus:ring-2 focus:ring-primary" %>
+      </div>
+
+      <!-- メールアドレス -->
+      <div>
+        <%= f.label :email,
+              "メールアドレス",
+              class: "text-sm text-base-content/70" %>
+
+        <%= f.email_field :email,
+              class: "w-full mt-1 text-lg font-medium text-base-content
+                      border border-base-300 rounded-sm p-2
+                      focus:outline-none focus:ring-2 focus:ring-primary" %>
+      </div>
+
+      <!-- アクション -->
+      <div class="flex flex-col items-center gap-4 pt-8">
+
+        <!-- 保存 -->
+        <%= f.submit "更新する",
+              class: "btn btn-primary w-40 text-center" %>
+
+        <!-- キャンセル -->
+        <%= link_to "キャンセル",
+              account_path,
+              class: "text-sm text-base-content/70 hover:underline" %>
+
+      </div>
+
+    </div>
+  <% end %>
+</div>

--- a/app/views/accounts/show.html.erb
+++ b/app/views/accounts/show.html.erb
@@ -6,13 +6,13 @@
     <!-- ユーザー名 -->
     <div>
       <p class="text-sm text-base-content/70">ユーザー名</p>
-      <p class="text-lg font-medium text-base-content"><%= current_user.name %></p>
+      <p class="text-lg font-medium text-base-content"><%= @account.name %></p>
     </div>
 
     <!-- メールアドレス -->
     <div>
       <p class="text-sm text-base-content/70">メールアドレス</p>
-      <p class="text-lg font-medium text-base-content"><%= current_user.email %></p>
+      <p class="text-lg font-medium text-base-content"><%= @account.email %></p>
     </div>
 
     <!-- アクション -->

--- a/app/views/accounts/show.html.erb
+++ b/app/views/accounts/show.html.erb
@@ -24,12 +24,13 @@
             class: "btn btn-primary w-40 text-center" %>
 
       <!-- 削除 -->
-      <%= button_to "アカウント削除",
+      <%= link_to "アカウント削除",
             account_path,
-            method: :delete,
-            data: { confirm: "本当に削除しますか？この操作は取り消せません。" },
+            data: {
+              turbo_method: :delete,
+              turbo_confirm: "アカウントを削除しますか？削除すると、すべてのデータが完全に失われ、復元することはできません。"
+            },
             class: "text-error text-sm hover:underline bg-transparent border-0 p-0 cursor-pointer" %>
-
     </div>
   </div>
 </div>

--- a/app/views/accounts/show.html.erb
+++ b/app/views/accounts/show.html.erb
@@ -1,0 +1,35 @@
+<div class="max-w-xl mx-auto mt-10">
+  <h1 class="text-base-content text-2xl font-bold mb-6">アカウント情報</h1>
+
+  <div class="p-6 space-y-4">
+    
+    <!-- ユーザー名 -->
+    <div>
+      <p class="text-sm text-base-content/70">ユーザー名</p>
+      <p class="text-lg font-medium text-base-content"><%= current_user.name %></p>
+    </div>
+
+    <!-- メールアドレス -->
+    <div>
+      <p class="text-sm text-base-content/70">メールアドレス</p>
+      <p class="text-lg font-medium text-base-content"><%= current_user.email %></p>
+    </div>
+
+    <!-- アクション -->
+    <div class="flex flex-col items-center gap-4 pt-12">
+      
+      <!-- 編集ボタン -->
+      <%= link_to "編集する",
+            edit_account_path,
+            class: "btn btn-primary w-40 text-center" %>
+
+      <!-- 削除 -->
+      <%= button_to "アカウント削除",
+            account_path,
+            method: :delete,
+            data: { confirm: "本当に削除しますか？この操作は取り消せません。" },
+            class: "text-error text-sm hover:underline bg-transparent border-0 p-0 cursor-pointer" %>
+
+    </div>
+  </div>
+</div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -45,9 +45,9 @@
         class="menu menu-sm dropdown-content bg-base-100 rounded-sm z-10 mt-3 w-52 p-2 shadow"
       >
         <li>
-          <%= link_to "マイページ（準備中）", "#", class: "text-sm py-3 px-4" %>
+          <%= link_to "アカウントを表示", account_path, class: "text-sm py-3 px-4" %>
         </li>
-        <li>
+        <li class="text-error">
           <%= link_to "ログアウト", destroy_user_session_path, data: { turbo_method: :delete }, class: "text-sm py-3 px-4" %>
         </li>
       </ul>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,8 @@ Rails.application.routes.draw do
 
   resource :advice, only: %i[show create]
 
+  resource :account, only: %i[show edit update]
+
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,7 +16,7 @@ Rails.application.routes.draw do
 
   resource :advice, only: %i[show create]
 
-  resource :account, only: %i[show edit update]
+  resource :account, only: %i[show edit update destroy]
 
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 

--- a/spec/requests/accounts_spec.rb
+++ b/spec/requests/accounts_spec.rb
@@ -1,0 +1,58 @@
+require 'rails_helper'
+
+RSpec.describe "Accounts", type: :request do
+  let(:user) { create(:user) }
+
+  before do
+    sign_in user
+  end
+
+  describe "GET /account/edit" do
+    it "編集画面が表示される" do
+      get edit_account_path
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe "PATCH /account" do
+    context "正常系" do
+      it "アカウントが更新される" do
+        patch account_path, params: {
+          user: { name: "新しい名前" }
+        }
+
+        expect(response).to redirect_to(account_path)
+        expect(user.reload.name).to eq "新しい名前"
+      end
+    end
+
+    context "異常系" do
+      it "更新失敗時はeditが再表示される" do
+        patch account_path, params: {
+          user: { name: "" } # バリデーションNG想定
+        }
+
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+  end
+
+  describe "DELETE /account" do
+    it "アカウントが削除される" do
+      expect {
+        delete account_path
+      }.to change(User, :count).by(-1)
+
+      expect(response).to redirect_to(root_path)
+    end
+  end
+
+  describe "未ログイン時" do
+    it "ログイン画面にリダイレクトされる" do
+      sign_out user
+      get edit_account_path
+
+      expect(response).to redirect_to(new_user_session_path)
+    end
+  end
+end


### PR DESCRIPTION
## 概要
ログインユーザーが自身のアカウント情報を編集・削除できる機能を実装しました。
あわせて、該当機能のリクエストスペックを追加しています。

## 作業内容
- resource :account を用いた単数リソースのルーティングを追加
- AccountsController の追加
- アカウント表示画面の追加（編集、削除ボタン設置）
- アカウント編集画面の追加
- RSpec（request spec）を追加
  - 編集画面表示のテスト
  - 更新処理（正常系・異常系）のテスト
  - 削除処理のテスト

Resolves: #112 
Resolves: #113 
